### PR TITLE
Fix: Disable `test` and `bench` targets again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ bsp_rpi4 = ["tock-registers"]
 [[bin]]
 name = "kernel"
 path = "src/main.rs"
+test = false
+bench = false
 
 ##--------------------------------------------------------------------------------------------------
 ## Dependencies


### PR DESCRIPTION
This was accidentally removed in https://github.com/RustOS2/rust-raspberrypi-OS-tutorials/commit/3845159ae985af49e46126a1f5ec2b0b494ee859